### PR TITLE
Other (smaller) patches

### DIFF
--- a/fscd/fscd.c
+++ b/fscd/fscd.c
@@ -72,8 +72,6 @@ __FBSDID("$FreeBSD$");
 #include <util.h>
 #endif
 
-#define DEBUGPRINT(...) if (debug) printlog(LOG_ERR, __VA_ARGS__);
-
 /* Portability to pkgsrc. */
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "/etc/"
@@ -109,11 +107,16 @@ struct fscd_cfg {
 	int kq;
 };
 
+struct restart_params {
+	struct fscd_cfg *config;
+	char *sname;
+};
+
 #if defined(__FreeBSD__)
 	static struct pidfh *pfh = NULL;
 #endif
 
-static int debug = 0;
+static int daemonize = 0;
 static char *socketname = NULL;
 static char *conffile = NULL;
 
@@ -150,6 +153,7 @@ main(int argc, char *argv[])
 	struct kevent kq_events;
 	struct stat nb_stat;
 	char errorstr[LINE_MAX];
+	int verbosity = 0;
 
 	/* check arguments */
 	while ((ch = getopt(argc, argv, "Vdvfs:c:")) != -1)
@@ -157,12 +161,15 @@ main(int argc, char *argv[])
 			case 'V': /* Print version string. */
 				version();
 				break;
+			case 'd': /* Daemonize. */
+				daemonize = 1;
+				break;
 			case 'c': /* Change config file */
 				if (asprintf(&conffile, "%s", optarg) <= 0)
 					err(1, "asprintf");
 				break;
-			case 'v': /* Debugging mode. */
-				debug = 1;
+			case 'v': /* Verbosity. */
+				++verbosity;
 				break;
 			case 'f': /* Force overwrite. */
 				force = 1;
@@ -177,6 +184,21 @@ main(int argc, char *argv[])
 		}
 	argc -= optind;
 	argv += optind;
+
+	switch (verbosity) {
+		case 0:
+			setlogmask(LOG_UPTO(LOG_WARNING));
+			break;
+		case 1:
+			setlogmask(LOG_UPTO(LOG_NOTICE));
+			break;
+		case 2:
+			setlogmask(LOG_UPTO(LOG_INFO));
+			break;
+		default:
+			setlogmask(LOG_UPTO(LOG_DEBUG));
+			break;
+	}
 
 	/* initialize values */
 	if (!socketname && asprintf(&socketname, "%s", SOCK_PATH) <= 0)
@@ -197,9 +219,7 @@ main(int argc, char *argv[])
 		err(1, "pidfile_open");
 #endif
 
-	if (debug)
-		printf("Debug mode. Not daemonizing.\n");
-	else if (daemon(0, 0) == -1)
+	if (daemonize && daemon(0, 0) == -1)
 		err(1, "daemon");
 
 #if defined(__FreeBSD__)
@@ -230,11 +250,15 @@ main(int argc, char *argv[])
 	signal(SIGUSR1, handle_sig);
 	signal(SIGUSR2, handle_sig);
 
+	printlog(LOG_NOTICE, "Starting.");
+
 	monthrint = pthread_create(&(config.service_thr), NULL,
 	    connect_monitor, &config);
 
 	/* Read configuration */
 	readconf(&config);
+
+	printlog(LOG_INFO, "Monitoring processes...");
 
 	while (1) {
 		newevent = kevent(config.kq, NULL, 0, &kq_events, 1, NULL);
@@ -288,7 +312,7 @@ handle_queue(struct fscd_cfg *config, struct kevent *kq_events)
 					    svs->svname);
 				} else if (pretcode == 0 && handle_waiting(config,
 				    svs->svname) == 0) {
-					printlog(LOG_ERR, "Waiting for %s to restart.",
+					printlog(LOG_ERR, "%s waiting for restart.",
 					    svs->svname);
 				} else {
 					printlog(LOG_ERR, "%s failed to restart.",
@@ -360,10 +384,11 @@ handle_restart(struct fscd_cfg *config, char *sname)
 			printlog(LOG_ERR, "Could not monitor service.");
 			return -1;
 		}
-		break;
+
+		return 0;
 	}
 
-	return 0;
+	return -1;
 }
 
 /*
@@ -373,14 +398,12 @@ static int
 handle_waiting(struct fscd_cfg *config, char *sname)
 {
 	pthread_t tmpthr;
-	struct  {
-		struct fscd_cfg *cfg;
-		char *name;
-	} tmpv;
+	struct restart_params *inputv;
 
-	tmpv.cfg = config;
-	tmpv.name = sname;
-	return pthread_create(&tmpthr, NULL, wait_restart, &tmpv);
+	inputv = malloc(sizeof(struct restart_params));
+	inputv->config = config;
+	inputv->sname = strdup(sname);
+	return pthread_create(&tmpthr, NULL, wait_restart, inputv);
 }
 
 /*
@@ -389,10 +412,7 @@ handle_waiting(struct fscd_cfg *config, char *sname)
 static void *
 wait_restart(void *var)
 {
-	struct {
-		struct fscd_cfg *config;
-		char *sname;
-	} *inputv;
+	struct restart_params *inputv;
 	struct service *svs;
 	struct spid *svpid;
 	int retries;
@@ -420,6 +440,8 @@ wait_restart(void *var)
 					    "restarted, but not by me.",
 					    svs->svname);
 				pthread_mutex_unlock(&inputv->config->service_mtx);
+				free(inputv->sname);
+				free(inputv);
 				return NULL;
 			}
 			pthread_mutex_unlock(&inputv->config->service_mtx);
@@ -429,19 +451,28 @@ wait_restart(void *var)
 			printlog(LOG_ERR, "Service %s was removed from "
 			    "monitoring while I was waiting for it to restart.",
 			    inputv->sname);
+			free(inputv->sname);
+			free(inputv);
 			return NULL;
 		}
 		sleep(10);
 	}
 	printlog(LOG_ERR, "Service %s was not restarted. Doing it myself.",
-	    inputv->sname);
+	    svs->svname);
 	pthread_mutex_lock(&inputv->config->service_mtx);
-	handle_restart(inputv->config, inputv->sname);
+	if (handle_restart(inputv->config, svs->svname) == 0) {
+		printlog(LOG_ERR, "%s was restarted",
+			svs->svname);
+	} else {
+		printlog(LOG_ERR, "%s failed to restart.",
+				svs->svname);
+		printlog(LOG_ERR, "%s removed from monitoring.",
+				svs->svname);
+		unregister_service(inputv->config, svs->svname);
+	}
 	pthread_mutex_unlock(&inputv->config->service_mtx);
-	return NULL;
-
-	printlog(LOG_ERR, "Service %s should be waited for, but was not found.",
-	    inputv->sname);
+	free(inputv->sname);
+	free(inputv);
 	return NULL;
 }
 
@@ -535,7 +566,8 @@ usage(void)
 	fprintf(stderr, "usage: fscd\n"
 					"options:\n"
 					"	-V   Show version info.\n"
-					"	-v   Debugging: Don't fork.\n"
+					"	-d   Daemonize.\n"
+					"	-v   Verbosity, use multiple times.\n"
 					"	-s S Use socket S.\n"
 					"	-c C Use config file C.\n");
 	exit(EX_USAGE);
@@ -562,12 +594,7 @@ printlog(int priority, const char *logstr, ...)
 
 	va_start(tmplist, logstr);
 
-	if (debug) {
-		vfprintf(stdout, logstr, tmplist);
-		fprintf(stdout, "\n");
-	} else {
-		vsyslog(priority, logstr, tmplist);
-	}
+	vsyslog(priority, logstr, tmplist);
 
 	va_end(tmplist);
 	return;
@@ -714,7 +741,7 @@ fill_pids(struct service *svs)
 		 * in its rc script and we could thus just parse the script
 		 * ourselves, exceptions here might have the same probability
 		 * as services with different service and script names
-		 * So we have to skip the first portion up to the 
+		 * So we have to skip the first portion up to the
 		 * "is not running" or "is runnind as pid" and assume
 		 * service(8) returns the right script's output.
 		 */
@@ -836,17 +863,8 @@ kqueue_service(struct fscd_cfg *config, struct service *svs)
 static int
 register_service(struct fscd_cfg *config, struct service *svs)
 {
-	int ret;
-	char errorstr[LINE_MAX];
-
-	if (SLIST_EMPTY(&svs->svpids) && (ret=fill_pids(svs))) {
-		if (strerror_r(errno, errorstr, sizeof errorstr))
-			printlog(LOG_ERR, "Getting pids failed");
-		else
-			printlog(LOG_ERR, "Getting pids failed: %s",
-			    errorstr);
-		return ret;
-	}
+	if (SLIST_EMPTY(&svs->svpids))
+		fill_pids(svs);
 
 	if (kqueue_service(config, svs))
 		return -1;
@@ -876,6 +894,7 @@ unregister_service(struct fscd_cfg *config, char *svc_name_in)
 				free(svpid);
 			}
 			printlog(LOG_INFO, "%s has been removed.", svs->svname);
+			free(svs->svname);
 			free(svs);
 			ret = 0;
 			break;
@@ -937,7 +956,11 @@ readconf(struct fscd_cfg *config)
 						    "%cetc/rc.conf.",
 						    svs->svname, svs->svname,
 						    '/');
+					free(svs->svname);
 					free(svs);
+				} else {
+					printlog(LOG_INFO, "%s is being monitored.",
+					    svs->svname);
 				}
 			}
 		} else {
@@ -967,6 +990,7 @@ readconf(struct fscd_cfg *config)
 						    "%cetc/rc.conf.",
 						    svs->svname, svs->svname,
 						    '/');
+					free(svs->svname);
 					free(svs);
 				} else if ((ret=register_service(config, svs))) {
 					if (ret < 0)
@@ -980,7 +1004,14 @@ readconf(struct fscd_cfg *config)
 						    "%cetc/rc.conf.",
 						    svs->svname, svs->svname,
 						    '/');
+					free(svs->svname);
 					free(svs);
+				} else if ((ret=handle_waiting(config, svs->svname))) {
+					printlog(LOG_ERR, "%s failed to wait for start.",
+							svs->svname);
+					printlog(LOG_ERR, "%s removed from monitoring.",
+							svs->svname);
+					unregister_service(config, svs->svname);
 				} else {
 					printlog(LOG_INFO, "%s started from "
 					    "config file.", svs->svname);
@@ -1007,6 +1038,8 @@ connect_monitor(void *var)
 	struct fscd_cfg *config;
 	char taskstr[LINE_MAX];
 	char errorstr[LINE_MAX];
+
+	printlog(LOG_INFO, "Server thread started.");
 
 	config = var;
 	memset(&local, 0, sizeof(local));

--- a/rc.d/fscd
+++ b/rc.d/fscd
@@ -15,8 +15,13 @@
 name="fscd"
 desc="FreeBSD Services Control Daemon"
 rcvar="fscd_enable"
-command="/usr/sbin/${name}"
+command="/usr/local/sbin/${name}"
 pidfile="/var/run/${name}.pid"
+required_files="/usr/local/etc/$name.conf"
 
 load_rc_config $name
+: ${fscd_enable="NO"}
+: ${fscd_flags=""}
+command_args="-d"
+
 run_rc_command "$1"


### PR DESCRIPTION
Over the years I've also added a few features/improvements to fscd.

This pull request includes the following:

+ rc.d: Using `/usr/local/sbin/fscd` command
+ rc.d: Require configuration file
+ Fixes thread safety analysis compilation
+ Daemonize option added (`-d`)
+ Verbosity option uses `setlogmask()` is now used instead of `DEBUGPRINT`
+ Doesn't immediately starts manually killed services, instead wait a
  while for those to start by themselves.
+ Fixes issue when starting fscd while services are still being started.
+ Remove yet other trailing space
